### PR TITLE
call setState inside of connectToStores' componentDidMount method

### DIFF
--- a/connectToStores.js
+++ b/connectToStores.js
@@ -23,6 +23,9 @@ function createComponent(Component, stores, getStateFromStores, customContextTyp
             stores.forEach(function storesEach(Store) {
                 this.context.getStore(Store).addChangeListener(this._onStoreChange);
             }, this);
+
+            // may have missed store changes before setting listeners
+            this.setState(this.getStateFromStores());
         },
         componentWillUnmount: function componentWillUnmount() {
             stores.forEach(function storesEach(Store) {


### PR DESCRIPTION
since `componentDidMount` is not guaranteed to execute in parent > child order (see: https://github.com/facebook/react/issues/2763). This means that store changes could occur before listeners are attached.