### PR TITLE
Add child component displayName to provideContext

### DIFF
--- a/provideContext.js
+++ b/provideContext.js
@@ -9,13 +9,14 @@ var objectAssign = require('object-assign');
 var hoistNonReactStatics = require('hoist-non-react-statics');
 
 function createComponent(Component, customContextTypes) {
+    var componentName = Component.displayName || Component.name;
     var childContextTypes = objectAssign({
         executeAction: React.PropTypes.func.isRequired,
         getStore: React.PropTypes.func.isRequired
     }, customContextTypes || {});
 
     var ContextProvider = React.createClass({
-        displayName: 'ContextProvider',
+        displayName: componentName + 'ContextProvider',
 
         propTypes: {
             context: React.PropTypes.object.isRequired

--- a/tests/unit/lib/provideContext.js
+++ b/tests/unit/lib/provideContext.js
@@ -6,6 +6,29 @@ var React = require('react');
 var provideContext = require('../../..').provideContext;
 
 describe('provideContext', function () {
+    it('should use the childs name', function () {
+        var Component = React.createClass({
+            render: function () {
+                return null;
+            }
+        });
+
+        var WrappedComponent = provideContext(Component);
+        expect(WrappedComponent.displayName).to.equal('ComponentContextProvider');
+    });
+
+    it('should use the childs displayName', function () {
+        var Component = React.createClass({
+            displayName: 'TestComponent',
+            render: function () {
+                return null;
+            }
+        });
+
+        var WrappedComponent = provideContext(Component);
+        expect(WrappedComponent.displayName).to.equal('TestComponentContextProvider');
+    });
+
     it('should provide the context with custom types to children', function () {
         var context = {
             foo: 'bar',


### PR DESCRIPTION
Names `provideContext` using the wrapped component's `displayName` in the same way that `connectToStores` does.